### PR TITLE
fix(vite-legacy): add @nuxt/nitro-server type import

### DIFF
--- a/src/runtime/server/plugin/vite-legacy.ts
+++ b/src/runtime/server/plugin/vite-legacy.ts
@@ -1,3 +1,4 @@
+import type {} from '@nuxt/nitro-server'
 import type { NitroAppPlugin } from 'nitropack'
 import type { ModuleOptions } from '../../../../src/module'
 import {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal type imports for improved development compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->