### PR TITLE
ci: skip BrowserStack E2E on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,34 @@ jobs:
       - name: Test
         run: npm run test
 
-      # Real-browser E2E via BrowserStack Automate (Selenium). Verifies that the
-      # legacy chunks + polyfills actually hydrate the playground in Chrome
-      # 49/61/91. Forked PRs need maintainer approval before CI runs, so the
-      # secrets are available by the time this executes. Requires repo secrets
-      # BROWSERSTACK_USERNAME and BROWSERSTACK_ACCESS_KEY.
+  # Real-browser E2E via BrowserStack Automate (Selenium). Verifies that the
+  # legacy chunks + polyfills actually hydrate the playground in Chrome
+  # 49/61/91. Requires repo secrets BROWSERSTACK_USERNAME and
+  # BROWSERSTACK_ACCESS_KEY.
+  #
+  # GitHub does not expose repo secrets to `pull_request` runs triggered from a
+  # fork (secrets stay empty even after a maintainer approves the run), so this
+  # job is skipped on cross-repo PRs. Fork PRs are covered by the `test` job;
+  # E2E runs on same-repo PRs and on every push to main.
+  test:e2e:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - run: corepack enable
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.16.0
+      - name: Upgrade corepack
+        run: npm i -g corepack@latest
+
+      - name: Install dependencies
+        run: npx nypm@latest i
+
+      - name: Playground prepare
+        run: npm run dev:prepare
+
       - name: Run BrowserStack Automate E2E
         timeout-minutes: 20
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
   # fork (secrets stay empty even after a maintainer approves the run), so this
   # job is skipped on cross-repo PRs. Fork PRs are covered by the `test` job;
   # E2E runs on same-repo PRs and on every push to main.
-  test:e2e:
+  test_e2e:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
 


### PR DESCRIPTION
GitHub does not expose repo secrets to `pull_request` runs triggered from a fork — the secrets stay empty even after a maintainer approves the run. This is why the E2E job on #141 failed with missing `BROWSERSTACK_USERNAME` / `BROWSERSTACK_ACCESS_KEY` credentials.

## Changes

- Split the BrowserStack E2E step out of `test` into its own `test:e2e` job.
- Gate `test:e2e` to same-repo sources only: `push` events and PRs whose head repo is the target repository (`github.event.pull_request.head.repo.full_name == github.repository`).
- Fork PRs keep running the secret-free `test` (lint + unit tests); only the real-browser E2E is skipped.
- Corrected the prior comment that incorrectly claimed secrets become available after maintainer approval.

## Why not `pull_request_target`?

It would expose secrets on fork PRs, but it runs the workflow from the **target** branch while checking out **PR** code — i.e. untrusted code with access to the BrowserStack credentials. Not worth the risk for an E2E job.

## Effect on #141

After this lands, the E2E job on fork PRs like #141 will be skipped instead of failing, so it no longer blocks merge.