### PR TITLE
chore: set minimumReleaseAge to 6h and exclude nuxt nightly packages

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,11 +1,12 @@
 catalogMode: prefer
 cleanupUnusedCatalogs: true
+minimumReleaseAge: 360 # 6 hours
 minimumReleaseAgeExclude:
-  - '@nuxt/kit-nightly@5.0.0-29699187.9208a469'
-  - '@nuxt/nitro-server-nightly@5.0.0-29699187.9208a469'
-  - '@nuxt/schema-nightly@5.0.0-29699187.9208a469'
-  - '@nuxt/vite-builder-nightly@5.0.0-29699187.9208a469'
-  - nuxt-nightly@5.0.0-29699187.9208a469
+  - '@nuxt/kit-nightly'
+  - '@nuxt/nitro-server-nightly'
+  - '@nuxt/schema-nightly'
+  - '@nuxt/vite-builder-nightly'
+  - nuxt-nightly
 shamefullyHoist: true
 shellEmulator: true
 


### PR DESCRIPTION
## Description

- Set `minimumReleaseAge: 360` (6 hours) in `pnpm-workspace.yaml` to enforce a release-age gate on newly published packages.
- Simplify `minimumReleaseAgeExclude` entries by dropping version pins, keeping all nuxt nightly packages excluded:
  - `@nuxt/kit-nightly`
  - `@nuxt/nitro-server-nightly`
  - `@nuxt/schema-nightly`
  - `@nuxt/vite-builder-nightly`
  - `nuxt-nightly`

This ensures the release-age check does not block nightly nuxt releases, which are consumed via the `dev:nuxt-v5` catalog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace configuration to adjust release age policies for package management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->