### PR TITLE
test: update legacy browser e2e matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
   # Real-browser E2E via BrowserStack Automate (Selenium). Verifies that the
   # legacy chunks + polyfills actually hydrate the playground in Chrome
-  # 49/61/91. Requires repo secrets BROWSERSTACK_USERNAME and
+  # 49/61/104/105/latest. Requires repo secrets BROWSERSTACK_USERNAME and
   # BROWSERSTACK_ACCESS_KEY.
   #
   # GitHub does not expose repo secrets to `pull_request` runs triggered from a

--- a/README.md
+++ b/README.md
@@ -81,18 +81,19 @@ Check the results for current module version:
 
 > The test result runs with custom `AbortController` polyfill, which is not included in this module and you need to add it by yourself, see [Custom Polyfills](#custom-polyfills).
 
-| Nuxt Version | @vitejs/plugin-legacy | Chrome 49                     | Chrome 61                     | Chrome 91 |
-| ------------ | --------------------- | ----------------------------- | ----------------------------- | --------- |
-| 4.5.x        | 8.x                   | ✅ (with `minify: 'terser'`) | ✅ (with `minify: 'terser'`) | ✅ PASS   |
+| Nuxt Version | @vitejs/plugin-legacy | Chrome 49                     | Chrome 61                     | Chrome 104 | Chrome 105 | Latest Chrome |
+| ------------ | --------------------- | ----------------------------- | ----------------------------- | ---------- | ---------- | ------------- |
+| 4.5.x        | 8.x                   | ✅ (with `minify: 'terser'`) | ✅ (with `minify: 'terser'`) | ✅ legacy  | ✅ modern  | ✅ modern     |
 
 ### Browser support
 
 The module is tested with the following browsers:
 
-- Chrome 49: the oldest Chrome version full Proxy support
-- Chrome 61: supports ESM but does not support [widely-available features](https://vite.dev/guide/build.html#browser-compatibility)
-- Chrome 91: does not support `Object.hasOwn`, but it can be polyfilled
-- Latest Chrome
+- Chrome 49: the oldest Chrome version with full Proxy support; exercises the non-ESM legacy path
+- Chrome 61: supports ESM but not dynamic import; exercises the ESM fallback path
+- Chrome 104: the last version before `import.meta.resolve`; exercises the plugin-legacy v8 fallback boundary
+- Chrome 105: the first modern Chrome target in plugin-legacy v8; exercises modern chunks and the `Array.prototype.toSorted` polyfill
+- Latest Chrome: regression guard for current browsers
 
 You can test by yourself by visiting the [playground](https://nuxt-legacy.pages.dev/) with your target browsers.
 

--- a/playgrounds/v4/app/app.vue
+++ b/playgrounds/v4/app/app.vue
@@ -6,6 +6,7 @@
     <h1>@teages/nuxt-legacy</h1>
     <DynamicImport />
     <ObjectHasOwnPolyfill />
+    <ArrayToSortedPolyfill />
 
     <div>
       Try these browsers to visit the page:

--- a/playgrounds/v4/app/components/ArrayToSortedPolyfill.vue
+++ b/playgrounds/v4/app/components/ArrayToSortedPolyfill.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+const source = [3, 1, 2]
+
+const { data, status } = useAsyncData(async () => {
+  return source.toSorted((a, b) => a - b).join(',')
+}, { server: false })
+</script>
+
+<template>
+  <div>
+    If you see a sorted copy below, it means Array.prototype.toSorted works:
+    <div>
+      <span v-if="status === 'success'">Array.toSorted result: {{ data }}</span>
+      <span v-else>Loading...</span>
+    </div>
+  </div>
+</template>

--- a/playgrounds/v4/app/components/BrowserSuggestion.vue
+++ b/playgrounds/v4/app/components/BrowserSuggestion.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 const suggestion = computed(() => [
   {
-    caniuse: 'https://caniuse.com/proxy',
+    url: 'https://caniuse.com/proxy',
     feature: 'Proxy',
     reason: 'Requirement for Vue',
 
@@ -10,7 +10,7 @@ const suggestion = computed(() => [
     safari: '10',
   },
   {
-    caniuse: 'https://caniuse.com/es6-module',
+    url: 'https://caniuse.com/es6-module',
     feature: 'ES6 Modules',
     reason: 'Requirement for vite native support',
 
@@ -19,7 +19,7 @@ const suggestion = computed(() => [
     safari: '11',
   },
   {
-    caniuse: 'https://caniuse.com/es6-module-dynamic-import',
+    url: 'https://caniuse.com/es6-module-dynamic-import',
     feature: 'Dynamic import',
     reason: 'Requirement for vite native support',
 
@@ -28,7 +28,7 @@ const suggestion = computed(() => [
     safari: '11.1',
   },
   {
-    caniuse: 'https://caniuse.com/mdn-javascript_operators_import_meta',
+    url: 'https://caniuse.com/mdn-javascript_operators_import_meta',
     feature: 'import.meta',
     reason: 'Requirement for vite native support',
 
@@ -37,7 +37,16 @@ const suggestion = computed(() => [
     safari: '11.1',
   },
   {
-    caniuse: 'https://caniuse.com/mdn-javascript_builtins_object_hasown',
+    url: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve',
+    feature: 'import.meta.resolve',
+    reason: 'Requirement for vite modern chunks',
+
+    chrome: '105',
+    firefox: '106',
+    safari: '16.4',
+  },
+  {
+    url: 'https://caniuse.com/mdn-javascript_builtins_object_hasown',
     feature: 'Object.hasOwn',
     reason: 'Test for Object.hasOwn polyfill',
 
@@ -45,11 +54,20 @@ const suggestion = computed(() => [
     firefox: '92',
     safari: '15.4',
   },
+  {
+    url: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted',
+    feature: 'Array.prototype.toSorted',
+    reason: 'Test for modern polyfill',
+
+    chrome: '110',
+    firefox: '115',
+    safari: '16',
+  },
 ] satisfies BrowsersSuggestion[])
 
 interface BrowsersSuggestion {
   feature: string
-  caniuse: string
+  url: string
   reason: string
 
   chrome: string
@@ -71,9 +89,9 @@ interface BrowsersSuggestion {
         </tr>
       </thead>
       <tbody>
-        <tr v-for="item in suggestion" :key="item.caniuse">
+        <tr v-for="item in suggestion" :key="item.url">
           <td>
-            <NuxtLink :to="item.caniuse">
+            <NuxtLink :to="item.url">
               {{ item.feature }}
             </NuxtLink>
           </td>

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -42,15 +42,16 @@ const LOCAL_IDENTIFIER = 'nuxt-legacy'
 const DEBUG = process.env.E2E_DEBUG === '1'
 
 // Chrome versions mapped to the module's compatibility claims (see README):
-// 49  = min required for Vue 3 (Proxy)
-// 61  = ESM but pre "widely-available features"
-// 91  = no Object.hasOwn, needs core-js polyfill
+// 49     = min required for Vue 3 (Proxy), no native ESM
+// 61     = native ESM but no dynamic import
+// 104    = last Chrome before import.meta.resolve support
+// 105    = plugin-legacy v8's minimum modern Chrome target
 // latest = regression guard
 //
 // `isLegacy` records which chunk each version loads. plugin-legacy v8 changed
 // the modern/legacy boundary: its detect script now probes `import.meta.resolve`
-// (Chrome 105+), so Chrome 91 falls into the legacy bucket under v8 even though
-// v7 treated it as modern.
+// (Chrome 105+). Chrome 104 therefore exercises the new fallback boundary,
+// while Chrome 105 exercises the first modern version.
 //
 // `skipReason` skips a version when the toolchain can't support it. Currently
 // unused — the v4 playground sets `vite.build.minify: 'terser'` to work around
@@ -65,7 +66,8 @@ interface ChromeVersion {
 const CHROME_VERSIONS: readonly ChromeVersion[] = [
   { version: '49.0', isLegacy: true },
   { version: '61.0', isLegacy: true },
-  { version: '91.0', isLegacy: true },
+  { version: '104.0', isLegacy: true },
+  { version: '105.0', isLegacy: false },
   { version: 'latest', isLegacy: false },
 ]
 
@@ -74,6 +76,7 @@ const CHROME_VERSIONS: readonly ChromeVersion[] = [
 // dynamic import / polyfill on the client.
 const DYNAMIC_IMPORT_DONE = '1 + 2 = 3'
 const OBJECT_HAS_OWN_DONE = 'true'
+const ARRAY_TO_SORTED_DONE = 'Array.toSorted result: 1,2,3'
 
 // DecideIsLegacy reports which build the browser loaded, via the compile-time
 // `import.meta.env.LEGACY` flag (true in the legacy build, false in the modern
@@ -300,14 +303,19 @@ async function assertHydrated(driver: WebDriver, chromeVersion: string, isLegacy
   // once the legacy chunk executes the dynamic import on the client.
   await waitForText(driver, label, DYNAMIC_IMPORT_DONE)
 
-  // Secondary: Object.hasOwn is absent in Chrome < 93 — only reachable if the
-  // core-js polyfill loaded and the legacy entry executed.
+  // Secondary: Object.hasOwn is absent in Chrome <93, so the oldest sessions
+  // verify that it is present in the legacy polyfill chunk.
   await waitForText(driver, label, OBJECT_HAS_OWN_DONE)
 
-  // Tertiary: DecideIsLegacy reports which build the browser loaded, via the
+  // Chrome 105 runs the modern build but lacks Array.prototype.toSorted
+  // (introduced in Chrome 110), so this verifies the modern polyfill chunk.
+  // The older sessions exercise the corresponding legacy polyfill.
+  await waitForText(driver, label, ARRAY_TO_SORTED_DONE)
+
+  // DecideIsLegacy reports which build the browser loaded, via the
   // compile-time `import.meta.env.LEGACY` flag. Whether a Chrome version loads
   // the modern or legacy chunk depends on whether it supports the modern ESM
-  // features the detection script probes (import.meta, dynamic import, async
-  // iterators). Empirically: 49/61 fall back to legacy; 91/latest run modern.
+  // features the detection script probes (dynamic import, async generators,
+  // and import.meta.resolve). Chrome 49/61/104 use legacy; 105/latest use modern.
   await waitForText(driver, label, isLegacy ? LEGACY_BROWSER_MARKER : MODERN_BROWSER_MARKER)
 }

--- a/test/playground-v4.test.ts
+++ b/test/playground-v4.test.ts
@@ -3,4 +3,5 @@ import { describePlayground } from './utils/playground'
 describePlayground({
   name: 'Nuxt 4',
   dir: 'v4',
+  modernPolyfillContains: 'toSorted',
 })

--- a/test/utils/legacy-html.ts
+++ b/test/utils/legacy-html.ts
@@ -51,8 +51,12 @@ export function assertLegacyHtml(document: ParsedDocument) {
 export async function assertModernPolyfillsFirst(
   document: ParsedDocument,
   fetchText: (path: string) => Promise<string>,
+  expectedContent?: string,
 ) {
   const firstScript = document.querySelector('script[src]')
   const scriptContent = await fetchText(firstScript!.getAttribute('src')!)
   expect(scriptContent).toContain('https://github.com/zloirock/core-js')
+  if (expectedContent) {
+    expect(scriptContent).toContain(expectedContent)
+  }
 }

--- a/test/utils/playground.ts
+++ b/test/utils/playground.ts
@@ -11,6 +11,7 @@ interface PlaygroundTestOptions {
   dir: string
   server?: boolean
   viteEnvironmentApi?: boolean
+  modernPolyfillContains?: string
 }
 
 export function describePlayground(options: PlaygroundTestOptions) {
@@ -41,7 +42,7 @@ export function describePlayground(options: PlaygroundTestOptions) {
     it('serves modern polyfills as the first script', async () => {
       const document = parse(await $fetch('/'))
 
-      await assertModernPolyfillsFirst(document, $fetch)
+      await assertModernPolyfillsFirst(document, $fetch, options.modernPolyfillContains)
     })
 
     if (options.viteEnvironmentApi) {


### PR DESCRIPTION
## Summary

- update the BrowserStack matrix to Chrome 49, 61, 104, 105, and latest
- cover both sides of plugin-legacy v8's `import.meta.resolve` boundary
- add an `Array.prototype.toSorted` probe and assert that it is included in the modern polyfill chunk
- synchronize the playground compatibility table, README, and CI documentation

## Why

`@vitejs/plugin-legacy` v8 moved its modern Chrome threshold to Chrome 105. Chrome 91 therefore no longer exercised the modern build or modern polyfills as originally intended. Testing Chrome 104 and 105 directly covers the fallback boundary, while `toSorted` verifies a polyfill that Chrome 105 genuinely needs.

## Impact

The real-browser suite now runs five BrowserStack sessions instead of four. It retains the oldest supported and transitional ESM cases while adding explicit lower- and upper-boundary coverage for the current plugin-legacy behavior.

## Validation

- `pnpm test` — 26 tests passed
- `pnpm test:types`
- ESLint on all changed source and test files
- `pnpm test:e2e` — BrowserStack Chrome 49/61/104/105/latest, 5/5 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a playground demonstration of `Array.prototype.toSorted`, showing the computed sorted result.
  - Updated browser suggestions with direct links to relevant documentation and resources.

- **Documentation**
  - Updated browser support information to cover Chrome 49, 61, 104, 105, and the latest Chrome release.
  - Clarified compatibility and fallback behavior across supported browser versions.

- **Tests**
  - Expanded browser and hydration coverage for modern and legacy environments, including `toSorted` polyfill behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->