### PR TITLE
fix(ci): prepare module before packing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Install dependencies
         run: npx nypm@latest i
 
+      - name: Pack
+        run: pnpm pack --pack-destination ${{ runner.temp }}
+
       - name: Playground prepare
         run: npm run dev:prepare
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dist"
   ],
   "scripts": {
-    "prepack": "nuxt-module-build build",
+    "prepack": "nuxt-module-build prepare && nuxt-module-build build",
     "dev": "pnpm -C playgrounds/v4 dev",
     "dev:build": "pnpm -C playgrounds/v4 build",
     "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && pnpm --filter \"./playgrounds/*\" dev:prepare",


### PR DESCRIPTION
## Summary

- generate the Nuxt type configuration before the package build runs in `prepack`
- exercise `pnpm pack` in CI before the development prepare step

## Root cause

`uppt/pack` installs dependencies with lifecycle scripts disabled and then invokes `pnpm pack`. The package's `prepack` script previously ran `nuxt-module-build build` directly, but the root TypeScript configuration extends the generated `.nuxt/tsconfig.json`. A clean release runner therefore failed before producing a tarball, and the publish job was skipped.

Running `nuxt-module-build prepare` from `prepack` makes the package lifecycle self-contained. The added CI step covers the same clean packing path before `dev:prepare` can mask the missing generated file.

## Validation

- clean-directory `pnpm pack` produced `teages-nuxt-legacy-3.0.0.tgz`
- `pnpm test` — 10 files, 26 tests passed
- `pnpm test:types`
- `pnpm exec eslint . --ignore-pattern .omo`
