### PR TITLE
chore: migrate to shared renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,47 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base",
-    "group:allNonMajor",
-    ":semanticCommitTypeAll(chore)"
-  ],
-  "meteor": {
-    "enabled": false
-  },
-  "rangeStrategy": "bump",
-  "npm": {
-    "commitMessageTopic": "{{prettyDepType}} {{depName}}"
-  },
+  "extends": ["github>Teages/renovate-config"],
   "packageRules": [
     {
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "pin",
-        "digest"
-      ],
-      "automerge": true,
-      "automergeSchedule": [
-        "after 1pm and before 2pm"
-      ],
-      "schedule": [
-        "after 2pm and before 3pm"
-      ]
+      "enabled": false,
+      "matchDepTypes": ["peerDependencies"]
     },
     {
       "enabled": false,
-      "matchDepTypes": [
-        "peerDependencies"
-      ]
-    },
-    {
-      "enabled": false,
-      "matchPackageNames": [
-        "nuxt"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ]
+      "matchPackageNames": ["nuxt"],
+      "matchUpdateTypes": ["major"]
     }
   ]
 }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated dependency-management configuration.
  - Automatic scheduling and merging for minor, patch, pin, and digest updates are no longer enabled.
  - Peer-dependency updates remain disabled.
  - Major Nuxt updates remain blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->