### PR TITLE
chore: ignore plugin-legacy-v7 catalog alias in renovate

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,4 +19,12 @@ export default createConfigForNuxt({
         curly: ['error', 'all'],
       },
     }),
+    {
+      files: ['pnpm-workspace.yaml'],
+      rules: {
+        // Renovate writes double-quoted entries (e.g. minimumReleaseAgeExclude)
+        // into this file; do not enforce a quote style on it.
+        'yaml/quotes': 'off',
+      },
+    },
   )

--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,10 @@
       "enabled": false,
       "matchPackageNames": ["nuxt"],
       "matchUpdateTypes": ["major"]
+    },
+    {
+      "enabled": false,
+      "matchPackageNames": ["plugin-legacy-v7"]
     }
   ]
 }


### PR DESCRIPTION
Follow-up to closing #151.

- Disables renovate updates for the `plugin-legacy-v7` catalog alias, which intentionally pins `@vitejs/plugin-legacy` v7 to exercise the 'plugin major too old' compatibility path (`plugin-legacy-v8` already tracks v8).
- Disables `yaml/quotes` for `pnpm-workspace.yaml`: renovate writes double-quoted `minimumReleaseAgeExclude` entries on security updates, which kept failing `pnpm lint` (seen on #165/#166).